### PR TITLE
Cleanup setup_mac.sh

### DIFF
--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -72,8 +72,7 @@ sudo -H pip install --upgrade pip
 sudo -H pip3 install --upgrade pip
 
 #unrest
-sudo -H pip install unirest
-
+sudo -H pip2 install unirest
 
 #Androwarn dependencies
 sudo -H pip install Jinja2

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -115,7 +115,7 @@ sudo -H pip install smalisca
 )
 
 #whatweb
-sudo apt-get install -y whatweb
+# sudo apt-get install -y whatweb
 
 #trueseeing
 sudo pip3 install trueseeing

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -90,9 +90,9 @@ sudo -H pip install smalisca
 (
 	# Do this in a sub shell 
 	# so we don't need to cd back into the top level MARA dir
-	cd tools/
+	cd tools/ || exit
 	git clone --recursive https://github.com/rednaga/yara-python-1 yara-python
-	cd yara-python/
+	cd yara-python/ || exit
 	sudo -H python setup.py build --enable-dex install
 	sudo -H pip2 install apkid
 )

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -47,8 +47,15 @@ chmod +x *.sh
 #Package update
 brew update -v
 
-#Install python
-brew install python python3
+declare -a brew_packages
+brew_packages=(python python3 bash gnu-sed git tree figlet aha)
+# Sed will replace your BSD sed with GNU sed
+#aha - Ansi HTML Adapter
+
+for package in "${brew_packages[@]}"; do
+	brew install "${package}"
+done
+
 
 #Install pip
 curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
@@ -60,36 +67,13 @@ rm get-pip.py
 sudo -H pip install --upgrade pip
 sudo -H pip3 install --upgrade pip
 
-#Install bash
-brew install bash -v
-
 #Java JDK
 brew tap caskroom/cask -v
 brew tap caskroom/versions -v
 brew cask install java 
-
-#Sed
-#Will replace your BSD sed with GNU sed
-brew install gnu-sed 
-
-#Git
-brew install git -v
-
-#Tree
-brew install tree -v
-
-#Figlet
-brew install figlet -v
-
 #unrest
 sudo -H pip install unirest
 
-#aha - Ansi HTML Adapter
-#sudo apt-get -y install aha
-brew install aha -v
-
-#Python3
-brew install python3 -v
 
 #Androwarn dependencies
 sudo -H pip install Jinja2

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -45,7 +45,7 @@ rm ssl_testssl.sh.tmp
 chmod +x *.sh
 
 #Package update
-brew update -y -v
+brew update -v
 
 #Install python
 brew install python python3
@@ -61,35 +61,35 @@ sudo -H pip install --upgrade pip
 sudo -H pip3 install --upgrade pip
 
 #Install bash
-brew install bash -y -v
+brew install bash -v
 
 #Java JDK
-brew tap caskroom/cask -y -v
-brew tap caskroom/versions -y -v
-brew cask install java -y
+brew tap caskroom/cask -v
+brew tap caskroom/versions -v
+brew cask install java 
 
 #Sed
 #Will replace your BSD sed with GNU sed
-brew install gnu-sed --with-default-names -y
+brew install gnu-sed 
 
 #Git
-brew install git -y -v
+brew install git -v
 
 #Tree
-brew install tree -y -v
+brew install tree -v
 
 #Figlet
-brew install figlet -y -v
+brew install figlet -v
 
 #unrest
 sudo -H pip install unirest
 
 #aha - Ansi HTML Adapter
 #sudo apt-get -y install aha
-brew install aha -y -v
+brew install aha -v
 
 #Python3
-brew install python3 -y -v
+brew install python3 -v
 
 #Androwarn dependencies
 sudo -H pip install Jinja2

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -56,6 +56,10 @@ for package in "${brew_packages[@]}"; do
 	brew install "${package}"
 done
 
+#Java JDK
+brew tap caskroom/cask -v
+brew tap caskroom/versions -v
+brew cask install java 
 
 #Install pip
 curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
@@ -67,10 +71,6 @@ rm get-pip.py
 sudo -H pip install --upgrade pip
 sudo -H pip3 install --upgrade pip
 
-#Java JDK
-brew tap caskroom/cask -v
-brew tap caskroom/versions -v
-brew cask install java 
 #unrest
 sudo -H pip install unirest
 

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -104,12 +104,15 @@ sudo -H pip install configparser
 sudo -H pip install smalisca
 
 #APKiD
-cd tools/
-git clone --recursive https://github.com/rednaga/yara-python-1 yara-python
-cd yara-python/
-sudo -H python setup.py build --enable-dex install
-sudo -H pip install apkid
-cd ../../
+(
+	# Do this in a sub shell 
+	# so we don't need to cd back into the top level MARA dir
+	cd tools/
+	git clone --recursive https://github.com/rednaga/yara-python-1 yara-python
+	cd yara-python/
+	sudo -H python setup.py build --enable-dex install
+	sudo -H pip install apkid
+)
 
 #whatweb
 sudo apt-get install -y whatweb

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -75,16 +75,16 @@ sudo -H pip3 install --upgrade pip
 sudo -H pip2 install unirest
 
 #Androwarn dependencies
-sudo -H pip install Jinja2
+sudo -H pip3 install Jinja2
 
 #Smali graph generation dependency
-sudo -H pip install pydot
+sudo -H pip3 install pydot
 
 #configparser
-sudo -H pip install configparser
+sudo -H pip3 install configparser
 
 #Smalisca
-sudo -H pip install smalisca
+sudo -H pip3 install smalisca
 
 #APKiD
 (

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -121,7 +121,7 @@ sudo -H pip install smalisca
 sudo pip3 install trueseeing
 
 #Increase maximum java heap size for Jadx
-export JAVA_OPTS="-Xmx4G"
+echo "export JAVA_OPTS='-Xmx4G'" >> ~/.bashrc
 source ~/.bashrc
 
 #make tools executable

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -63,7 +63,7 @@ brew cask install java
 
 #Install pip
 curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-sudo -H python get-pip.py
+# sudo -H python get-pip.py
 sudo -H python3 get-pip.py
 rm get-pip.py
 

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -111,7 +111,7 @@ sudo -H pip install smalisca
 	git clone --recursive https://github.com/rednaga/yara-python-1 yara-python
 	cd yara-python/
 	sudo -H python setup.py build --enable-dex install
-	sudo -H pip install apkid
+	sudo -H pip2 install apkid
 )
 
 #whatweb


### PR DESCRIPTION
## Changes
- Remove `-y` option from `brew` commands
- Install `APKID` in sub shell to avoid `cd`ing back into `MARA` top level directory
- Remove `apt-get` commands 
- Explicitly call `pip2` or `pip3` rather than `pip`
- Remove installing `pip` for `python2` as macOS ships with it
- Install `brew` in a loop 
