### PR TITLE
Change Bash Scripts Shebang

### DIFF
--- a/apktool_cfg.sh
+++ b/apktool_cfg.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd tools/Smali-CFGs/
 mv ../../data/$file_/smali/apktool/android ../../data/$file_/smali/android_apktool

--- a/baksmali_cfg.sh
+++ b/baksmali_cfg.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd tools/Smali-CFGs/
 mv ../../data/$file_/smali/baksmali/android ../../data/$file_/smali/android_baksmali

--- a/cfg.sh
+++ b/cfg.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 _file=com.selfcare.safaricom-18.apk
 

--- a/de-guard.sh
+++ b/de-guard.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ################################################
 #Deguard Deobfuscation module by Munir Njiru"  #

--- a/deobfuscator.sh
+++ b/deobfuscator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 bold=`tput bold`
 normal=`tput sgr0`
 red='\e[0;31m'

--- a/mara.sh
+++ b/mara.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 bold=`tput bold`
 normal=`tput sgr0`

--- a/owasp_static_android.sh
+++ b/owasp_static_android.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 bold=`tput bold`
 normal=`tput sgr0`
 red='\e[0;31m'

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #These are the requirements for running this tool:
 

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #These are the requirements for running this tool:
 

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -2,46 +2,6 @@
 
 #These are the requirements for running this tool:
 
-#Update bash path in scripts
-sed -i.tmp 's|'/bin/bash'|/usr/local/bin/bash|g' apktool_cfg.sh >> apktool_cfg.sh.tmp
-rm apktool_cfg.sh.tmp
-
-sed -i.tmp 's|'/bin/bash'|/usr/local/bin/bash|g' deobfuscator.sh >> deobfuscator.sh.tmp
-rm deobfuscator.sh.tmp
-
-sed -i.tmp 's|'/bin/bash'|/usr/local/bin/bash|g' setup.sh >> setup.sh.tmp
-rm setup.sh.tmp
-
-sed -i.tmp 's|'/bin/bash'|/usr/local/bin/bash|g' update.sh >> update.sh.tmp
-rm update.sh.tmp
-
-sed -i.tmp 's|'/bin/bash'|/usr/local/bin/bash|g' baksmali_cfg.sh >> baksmali_cfg.sh.tmp
-rm baksmali_cfg.sh.tmp
-
-sed -i.tmp 's|'/bin/bash'|/usr/local/bin/bash|g' mara.sh >> mara.sh.tmp
-rm mara.sh.tmp
-
-sed -i.tmp 's|'/bin/bash'|/usr/local/bin/bash|g' ssl_pyssltest.sh >> ssl_pyssltest.sh.tmp
-rm ssl_pyssltest.sh.tmp
-
-sed -i.tmp 's|'/bin/bash'|/usr/local/bin/bash|g' cfg.sh >> cfg.sh.tmp
-rm cfg.sh.tmp
-
-sed -i.tmp 's|'/bin/bash'|/usr/local/bin/bash|g' owasp_static_android.sh >> owasp_static_android.sh.tmp
-rm owasp_static_android.sh.tmp
-
-sed -i.tmp 's|'/bin/bash'|/usr/local/bin/bash|g' ssl_scanner.sh >> ssl_scanner.sh.tmp
-rm ssl_scanner.sh.tmp
-
-sed -i.tmp 's|'/bin/bash'|/usr/local/bin/bash|g' de-guard.sh  >> de-guard.sh.tmp
-rm de-guard.sh.tmp
-
-sed -i.tmp 's|'/bin/bash'|/usr/local/bin/bash|g' setup_mac.sh >> setup_mac.sh.tmp
-rm setup_mac.sh.tmp
-
-sed -i.tmp 's|'/bin/bash'|/usr/local/bin/bash|g' ssl_testssl.sh >> ssl_testssl.sh.tmp
-rm ssl_testssl.sh.tmp
-
 chmod +x *.sh
 
 #Package update

--- a/ssl_pyssltest.sh
+++ b/ssl_pyssltest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 bold=`tput bold`
 normal=`tput sgr0`
 red='\e[0;31m'

--- a/ssl_scanner.sh
+++ b/ssl_scanner.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 bold=`tput bold`
 normal=`tput sgr0`
 red='\e[0;31m'

--- a/ssl_testssl.sh
+++ b/ssl_testssl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 bold=`tput bold`
 normal=`tput sgr0`
 red='\e[0;31m'

--- a/update.sh
+++ b/update.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 bold=`tput bold`
 normal=`tput sgr0`


### PR DESCRIPTION
For #16. 

In all bash scripts, replace the shebang

```
#!/bin/bash
```
with 
```
#!/usr/bin/env bash
```

The latter is more portable and allows us to remove the `sed` commands from `setup_mac.sh`
