### PR TITLE
setup_mac.sh cleanup

### DIFF
--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -6,6 +6,16 @@
 # Tested on:
 #	macOS Mojave (10.14.4)
 
+set -euo pipefail
+# -e exit if any command returns non-zero status code
+# -u prevent using undefined variables
+# -o pipefail force pipelines to fail on first non-zero status code
+
+IFS=$'\n\t'
+# Set Internal Field Separator to newlines and tabs
+# This makes bash consider newlines and tabs as separating words
+# See: http://redsymbol.net/articles/unofficial-bash-strict-mode/
+
 function check_brew_installed {
 
 	if ! [ -x "$(command -v brew)" ]; then

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -37,11 +37,6 @@ pip3_packages=(Jinja2 pydot configparser smalisca trueseeing)
 # Jinja2 - Androwarn dependencies
 # pydot - Smali graph generation dependency
 
-# Install pip3
-curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-sudo -H python3 get-pip.py
-rm get-pip.py
-
 # Upgrade pip
 sudo -H pip install --upgrade pip
 sudo -H pip3 install --upgrade pip

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
+# MARA_Framework/setup_mac.sh
 
-#These are the requirements for running this tool:
+# setup_mac.sh
+#   Install MARA dependencies
+# Tested on:
+#	macOS Mojave (10.14.4)
+
 
 chmod +x *.sh
 

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -4,14 +4,15 @@
 
 chmod +x *.sh
 
+declare -a brew_packages
 declare -a pip3_packages
+declare -a cleanup_dirs
 
 ## Brew ##
 
 # Update brew and all formulas
 brew update -v
 
-declare -a brew_packages
 brew_packages=(python python3 bash gnu-sed git tree figlet aha)
 # Sed will replace your BSD sed with GNU sed
 #aha - Ansi HTML Adapter
@@ -71,7 +72,6 @@ source ~/.bashrc
 chmod -R +x tools/
 
 #Clean up
-declare -a cleanup_dirs
 cleanup_dirs=(documentation_old tools_old update)
 
 for dir in "${cleanup_dirs[@]}"; do

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -41,7 +41,6 @@ function pip_deps {
 		sudo -H pip3 install "${package}"
 	done
 
-	# unrest
 	sudo -H pip2 install unirest
 }
 

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -15,13 +15,13 @@ brew update -v
 
 brew_packages=(python python3 bash gnu-sed git tree figlet aha)
 # Sed will replace your BSD sed with GNU sed
-#aha - Ansi HTML Adapter
+# aha - Ansi HTML Adapter
 
 for package in "${brew_packages[@]}"; do
 	brew install "${package}"
 done
 
-#Java JDK
+# Java JDK
 brew tap caskroom/cask -v
 brew tap caskroom/versions -v
 brew cask install java 
@@ -49,7 +49,7 @@ for package in "${pip3_packages[@]}"; do
 	sudo -H pip3 install "${package}"
 done
 
-#APKiD
+# APKiD
 (
 	# Do this in a sub shell 
 	# so we don't need to cd back into the top level MARA dir
@@ -60,18 +60,17 @@ done
 	sudo -H pip2 install apkid
 )
 
-#whatweb
-# sudo apt-get install -y whatweb
+# TODO: Install whatweb
+# https://github.com/urbanadventurer/WhatWeb
 
-
-#Increase maximum java heap size for Jadx
+# Increase maximum java heap size for Jadx
 echo "export JAVA_OPTS='-Xmx4G'" >> ~/.bashrc
 source ~/.bashrc
 
-#make tools executable
+# Make tools executable
 chmod -R +x tools/
 
-#Clean up
+# Clean up
 cleanup_dirs=(documentation_old tools_old update)
 
 for dir in "${cleanup_dirs[@]}"; do

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -92,6 +92,7 @@ function main {
 	source ~/.bashrc
 
 	# Make tools executable
+	sudo chown -R "${USER}" tools/
 	chmod -R +x tools/
 
 	clean_up

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -34,7 +34,6 @@ pip3_packages=(Jinja2 pydot configparser smalisca trueseeing)
 
 # Install pip3
 curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-# sudo -H python get-pip.py
 sudo -H python3 get-pip.py
 rm get-pip.py
 

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -6,6 +6,17 @@
 # Tested on:
 #	macOS Mojave (10.14.4)
 
+function check_brew_installed {
+
+	if ! [ -x "$(command -v brew)" ]; then
+		echo "Brew not installed"
+		echo "It is required to install some dependencies"
+		echo "https://brew.sh"
+
+		exit 1
+	fi
+}
+
 
 function brew_deps {
 	# Update brew and all formulas
@@ -87,6 +98,7 @@ function main {
 
 	make_shell_files_executable
 
+	check_brew_installed
 	brew_deps
 	install_java
 	pip_deps

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -4,6 +4,7 @@
 
 chmod +x *.sh
 
+declare -a pip3_packages
 
 ## Brew ##
 
@@ -24,30 +25,28 @@ brew tap caskroom/cask -v
 brew tap caskroom/versions -v
 brew cask install java 
 
-#Install pip
+## Pip ##
+
+pip3_packages=(Jinja2 pydot configparser smalisca trueseeing)
+# Jinja2 - Androwarn dependencies
+# pydot - Smali graph generation dependency
+
+# Install pip3
 curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 # sudo -H python get-pip.py
 sudo -H python3 get-pip.py
 rm get-pip.py
 
-#Upgrade pip
+# Upgrade pip
 sudo -H pip install --upgrade pip
 sudo -H pip3 install --upgrade pip
 
-#unrest
+# unrest
 sudo -H pip2 install unirest
 
-#Androwarn dependencies
-sudo -H pip3 install Jinja2
-
-#Smali graph generation dependency
-sudo -H pip3 install pydot
-
-#configparser
-sudo -H pip3 install configparser
-
-#Smalisca
-sudo -H pip3 install smalisca
+for package in "${pip3_packages[@]}"; do
+	sudo -H pip3 install "${package}"
+done
 
 #APKiD
 (
@@ -63,8 +62,6 @@ sudo -H pip3 install smalisca
 #whatweb
 # sudo apt-get install -y whatweb
 
-#trueseeing
-sudo pip3 install trueseeing
 
 #Increase maximum java heap size for Jadx
 echo "export JAVA_OPTS='-Xmx4G'" >> ~/.bashrc

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -7,75 +7,99 @@
 #	macOS Mojave (10.14.4)
 
 
-chmod +x *.sh
+function brew_deps {
+	# Update brew and all formulas
+	brew update -v
 
-declare -a brew_packages
-declare -a pip3_packages
-declare -a cleanup_dirs
+	brew_packages=(python python2 bash gnu-sed git tree figlet aha)
+	# Sed will replace your BSD sed with GNU sed
+	# aha - Ansi HTML Adapter
 
-## Brew ##
+	for package in "${brew_packages[@]}"; do
+		brew install "${package}"
+	done
+}
 
-# Update brew and all formulas
-brew update -v
 
-brew_packages=(python python2 bash gnu-sed git tree figlet aha)
-# Sed will replace your BSD sed with GNU sed
-# aha - Ansi HTML Adapter
+function install_java {
+	# Java JDK
+	brew tap caskroom/cask -v
+	brew tap caskroom/versions -v
+	brew cask install java
+}
 
-for package in "${brew_packages[@]}"; do
-	brew install "${package}"
-done
 
-# Java JDK
-brew tap caskroom/cask -v
-brew tap caskroom/versions -v
-brew cask install java 
+function pip_deps {
 
-## Pip ##
+	pip3_packages=(Jinja2 pydot configparser smalisca trueseeing)
+	# Jinja2 - Androwarn dependencies
+	# pydot - Smali graph generation dependency
 
-pip3_packages=(Jinja2 pydot configparser smalisca trueseeing)
-# Jinja2 - Androwarn dependencies
-# pydot - Smali graph generation dependency
+	# Upgrade pip
+	sudo -H pip install --upgrade pip
+	sudo -H pip3 install --upgrade pip
 
-# Upgrade pip
-sudo -H pip install --upgrade pip
-sudo -H pip3 install --upgrade pip
+	for package in "${pip3_packages[@]}"; do
+		sudo -H pip3 install "${package}"
+	done
 
-# unrest
-sudo -H pip2 install unirest
+	# unrest
+	sudo -H pip2 install unirest
+}
 
-for package in "${pip3_packages[@]}"; do
-	sudo -H pip3 install "${package}"
-done
 
-# APKiD
-(
-	# Do this in a sub shell 
-	# so we don't need to cd back into the top level MARA dir
-	cd tools/ || exit
-	git clone --recursive https://github.com/rednaga/yara-python-1 yara-python
-	cd yara-python/ || exit
-	sudo -H python setup.py build --enable-dex install
-	sudo -H pip2 install apkid
-)
+function install_apkid {
+	(
+		# Do this in a sub shell 
+		# so we don't need to cd back into the top level MARA dir
+		cd tools/ || exit
+		git clone --recursive https://github.com/rednaga/yara-python-1 yara-python
+		cd yara-python/ || exit
+		sudo -H python setup.py build --enable-dex install
+		sudo -H pip2 install apkid
+	)
+}
 
-# TODO: Install whatweb
-# https://github.com/urbanadventurer/WhatWeb
 
-# Increase maximum java heap size for Jadx
-echo "export JAVA_OPTS='-Xmx4G'" >> ~/.bashrc
-source ~/.bashrc
+function clean_up {
+	# Clean up
+	cleanup_dirs=(documentation_old tools_old update)
 
-# Make tools executable
-chmod -R +x tools/
+	for dir in "${cleanup_dirs[@]}"; do
+		if [[ -d "${dir}" ]]; then
+			rm -rf "{dir:?}"
+		fi
+	done
+}
 
-# Clean up
-cleanup_dirs=(documentation_old tools_old update)
 
-for dir in "${cleanup_dirs[@]}"; do
-	if [[ -d "${dir}" ]]; then
-		rm -rf "{dir:?}"
-	fi
-done
+function main {
+	
+	declare -a brew_packages
+	declare -a pip3_packages
+	declare -a cleanup_dirs
 
-exit 0
+	chmod +x *.sh
+
+	brew_deps
+	install_java
+	pip_deps
+	install_apkid
+
+	# TODO: Install whatweb
+	# https://github.com/urbanadventurer/WhatWeb
+
+	# Increase maximum java heap size for Jadx
+	echo "export JAVA_OPTS='-Xmx4G'" >> ~/.bashrc
+	source ~/.bashrc
+
+	# Make tools executable
+	chmod -R +x tools/
+
+	clean_up
+
+	exit 0
+}
+
+main "$@"
+

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -58,6 +58,15 @@ function install_apkid {
 }
 
 
+function make_shell_files_executable {
+	for file in $(echo ./*.sh); do 
+		if ! [ -x "${file}" ]; then
+			chmod +x "${file:?}"
+		fi
+	done
+}
+
+
 function clean_up {
 	# Clean up
 	cleanup_dirs=(documentation_old tools_old update)
@@ -76,7 +85,7 @@ function main {
 	declare -a pip3_packages
 	declare -a cleanup_dirs
 
-	chmod +x *.sh
+	make_shell_files_executable
 
 	brew_deps
 	install_java

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -18,7 +18,7 @@ declare -a cleanup_dirs
 # Update brew and all formulas
 brew update -v
 
-brew_packages=(python python3 bash gnu-sed git tree figlet aha)
+brew_packages=(python python2 bash gnu-sed git tree figlet aha)
 # Sed will replace your BSD sed with GNU sed
 # aha - Ansi HTML Adapter
 

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -4,7 +4,10 @@
 
 chmod +x *.sh
 
-#Package update
+
+## Brew ##
+
+# Update brew and all formulas
 brew update -v
 
 declare -a brew_packages

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -80,4 +80,4 @@ for dir in "${cleanup_dirs[@]}"; do
 	fi
 done
 
-exit
+exit 0

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -71,8 +71,13 @@ source ~/.bashrc
 chmod -R +x tools/
 
 #Clean up
-rm -r documentation_old/
-rm -r tools_old/
-rm -r update/
+declare -a cleanup_dirs
+cleanup_dirs=(documentation_old tools_old update)
+
+for dir in "${cleanup_dirs[@]}"; do
+	if [[ -d "${dir}" ]]; then
+		rm -rf "{dir:?}"
+	fi
+done
 
 exit

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -23,8 +23,6 @@ function brew_deps {
 
 function install_java {
 	# Java JDK
-	brew tap caskroom/cask -v
-	brew tap caskroom/versions -v
 	brew cask install java
 }
 


### PR DESCRIPTION
I've overhauled `setup_mac.sh`.

Cleaned up the executed commands, added some checks and then converted the whole script to using functions. 

- Check if directories exist before `rm`ing them
- For `brew` and `pip3` install packages in a loop
- Remove installing `pip` & `pip3`, they're included with `python` when installed via `brew`
- Change `brew` package from `python3` to `python2` 
  - Under `brew` `python` refers to `python3`
- Check if `brew` is installed before running it
- Add some `set` directives to enable [Unofficial Bash Strict Mode](http://redsymbol.net/articles/unofficial-bash-strict-mode/)

I've run these changes through `shellcheck` and there are no warnings or errors. 